### PR TITLE
Do not require secrets

### DIFF
--- a/.github/workflows/build-and-push-container-image.yml
+++ b/.github/workflows/build-and-push-container-image.yml
@@ -10,9 +10,9 @@ on:
         type: string
     secrets:
       QUAY_USERNAME:
-        required: true
+        required: false
       QUAY_PASSWORD:
-        required: true
+        required: false
 jobs:
   build-and-push-container-image:
     name: Build and push container image


### PR DESCRIPTION
They are not used on PRs, yet currently cause friction with forked repos.

See https://github.com/eu-nebulous/slo-violation-detector/pull/4